### PR TITLE
refactor: split css

### DIFF
--- a/frame.css
+++ b/frame.css
@@ -1,0 +1,100 @@
+#ago-chatbot {
+  border-radius: 16px;
+  bottom: 80px;
+  box-shadow: rgba(15, 15, 15, 0.16) 0px 5px 40px 0px;
+  display: block;
+  height: min(704px, 100% - 80px);
+  opacity: 1;
+  overflow: hidden;
+  pointer-events: all;
+  position: fixed;
+  right: 20px;
+  transform-origin: right bottom;
+  visibility: visible;
+  width: min(704px, 100% - 40px);
+  z-index: 2100000000;
+}
+#ago-chatbot.closed {
+  height: 0px;
+  left: 100%;
+  top: 100%;
+  width: 0px;  
+}
+#ago-iframe {
+  border: none;
+  height: 100%;
+  width: 100%;
+}
+#ago-chat-button {
+  align-items: center;
+  background-color: #007bff;
+  border: none;
+  border-radius: 50%;
+  top:calc(100vh - 68px);
+  box-shadow: 0 4px 12px rgba(0, 123, 255, 0.3);
+  cursor: pointer;
+  display: flex;
+  height: 48px;
+  justify-content: center;
+  left: calc(100vw - 68px);
+  padding: 12px;
+  position: fixed !important;
+  transition: all 0.2s ease;
+  width: 48px;
+  z-index: 2100000001;
+  /* Prevent iOS Safari from moving the button during scroll */
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
+  /* Additional positioning fixes for mobile */
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  will-change: transform;
+  /* Isolate from website layout changes */
+  margin: 0 !important;
+  box-sizing: border-box !important;
+  contain: layout style paint !important;
+}
+#ago-chat-button svg {
+  fill: #ffffff;
+}
+#ago-chat-button:not(.closed) #open-path,
+#ago-chat-button.closed #close-path {
+  display: none;
+}
+#ago-chat-button:hover {
+  box-shadow: 0 6px 16px rgba(0, 123, 255, 0.4);
+  scale: 1.1;
+}
+@media (max-width: 450px) {
+  #ago-chatbot {
+    border-radius: 0;
+    bottom: 0;
+    height: 100vh; /* Fallback for older browsers */
+    height: 100dvh;
+    left: 0;
+    right: 0;
+    top: 0;
+    width: 100vw; /* Fallback for older browsers */
+    width: 100dvw;
+    padding-top: env(safe-area-inset-top, 0px);
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    padding-left: env(safe-area-inset-left, 0px);
+    padding-right: env(safe-area-inset-right, 0px);
+  }
+  #ago-chatbot.closed {
+    height: 0px;
+    left: 100%;
+    top: 100%;
+    width: 0px;  
+  }
+  #ago-chat-button:not(.closed) {
+    display: none;
+  }
+  /* Fix for iOS Safari scroll behavior */
+  body.ago-chat-open {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+  }
+}


### PR DESCRIPTION
Split CSS to let websites with Content Security Policy add an exception for this domain instead of `unsafe-inline` that would allow any script to inject CSS.