### PR TITLE
feat: remove support for non responsive web apps

### DIFF
--- a/frame.css
+++ b/frame.css
@@ -30,16 +30,14 @@
   background-color: #007bff;
   border: none;
   border-radius: 50%;
-  top:calc(100vh - 68px);
-  top:calc(100dvh - 68px);
+  bottom: 20px;
   box-shadow: 0 4px 12px rgba(123, 123, 123, 0.3);  cursor: pointer;
   display: flex;
   height: 48px;
   justify-content: center;
-  left: calc(100vw - 68px);
-  left: calc(100dvw - 68px);
   padding: 12px;
   position: fixed !important;
+  right: 20px;
   transition: scale 0.2s ease;
   width: 48px;
   z-index: 2100000001;

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         </div>
         <div class="flex-1 flex justify-center">
             <img src="https://images.unsplash.com/photo-1512436991641-6745cdb1723f?auto=format&fit=crop&w=500&q=80"
-                 alt="Fashion Model" class="rounded-2xl shadow-2xl w-96 object-cover">
+                 alt="Fashion Model" width="100%">
         </div>
     </div>
 </section>
@@ -52,7 +52,7 @@
         <!-- Product 1 -->
         <div class="bg-white rounded-2xl shadow-lg p-6 flex flex-col">
             <img src="https://images.unsplash.com/photo-1503342217505-b0a15ec3261c?auto=format&fit=crop&w=400&q=80"
-                 alt="T-Shirt" class="rounded-xl mb-4 object-cover h-60">
+                 alt="T-Shirt" width="100%">
             <h3 class="font-bold text-lg mb-2">Classic White Tee</h3>
             <p class="text-gray-600 mb-2">Organic cotton. Timeless fit. Minimalist.</p>
             <span class="font-bold text-xl mb-4">$29</span>
@@ -63,7 +63,7 @@
         <!-- Product 2 -->
         <div class="bg-white rounded-2xl shadow-lg p-6 flex flex-col">
             <img src="https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=400&q=80"
-                 alt="Denim Jacket" class="rounded-xl mb-4 object-cover h-60">
+                 alt="Denim Jacket" width="100%">
             <h3 class="font-bold text-lg mb-2">Denim Jacket</h3>
             <p class="text-gray-600 mb-2">Heavyweight denim. Relaxed fit. All-season essential.</p>
             <span class="font-bold text-xl mb-4">$69</span>


### PR DESCRIPTION
We had positioned the button from the top left to avoid it being hidden when the site is not responsive.
This creates a small effect when the nav appears and disappears on scrolling.
To avoid this effect, we go back to positioning from the bottom right and drop support for non responsive websites

The HTML of the test page is updated accordingly